### PR TITLE
Fix compilation under Qt 5.6 and lower

### DIFF
--- a/QDiscord/src/qdiscord.d/qdiscordchannel.hpp
+++ b/QDiscord/src/qdiscord.d/qdiscordchannel.hpp
@@ -19,6 +19,7 @@
 #ifndef QDISCORDCHANNEL_HPP
 #define QDISCORDCHANNEL_HPP
 
+#include <QSharedPointer>
 #include <QJsonObject>
 #include <QDateTime>
 #include "qdiscorduser.hpp"


### PR DESCRIPTION
Fixes `error: implicit instantiation of undefined template` for the `QSharedPointer` template class .